### PR TITLE
fix(renovate workflow): set the correct docker image and version

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,6 +22,6 @@ jobs:
         with:
           configurationFile: renovate-runner-config.json
           token: ${{ secrets.RENOVATE_TOKEN }}
-          renovate-image: 37.413.3
-          renovate-version: latest
+          renovate-image: ghcr.io/renovatebot/renovate
+          renovate-version: 37.413.3
 


### PR DESCRIPTION
# Description

Fixes issues with the renovate workflow:
- renovate-image and renovate-version where incorrectly set