### PR TITLE
fix(workflow): separate job in two identical steps with one for dry runs

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Run Self-hosted Renovate
+      - name: Run Self-hosted Renovate (Dry Run)
+        if: ${{ github.event.inputs.dry_run && github.event.inputs.dry_run != 'off' }}
         uses: renovatebot/github-action@21d88b0bf0183abcee15f990011cca090dfc47dd # v40.1.12
         with:
           configurationFile: renovate-runner-config.json
@@ -36,4 +37,13 @@ jobs:
           renovate-image: ghcr.io/renovatebot/renovate
           renovate-version: 37.413.3
         env:
-          RENOVATE_DRY_RUN: ${{ github.event.inputs.dry_run == 'off' && null || github.event.inputs.dry_run || null }}
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dry_run }}
+
+      - name: Run Self-hosted Renovate
+        if: ${{ !github.event.inputs.dry_run || github.event.inputs.dry_run == 'off' }}
+        uses: renovatebot/github-action@21d88b0bf0183abcee15f990011cca090dfc47dd # v40.1.12
+        with:
+          configurationFile: renovate-runner-config.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          renovate-image: ghcr.io/renovatebot/renovate
+          renovate-version: 37.413.3


### PR DESCRIPTION
# Description

Separate the `Run Self-hosted Renovate` step into two distinct ones. The `RENOVATE_DRY_RUN` environment variable should not be present in normal runs  

## Type of change

:bug: Bug fix (non-breaking change which fixes an issue)  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
