### PR TITLE
feat(default): prefix mrkdwn updates with docs and pin docker images sha

### DIFF
--- a/renovate-default-config.json
+++ b/renovate-default-config.json
@@ -11,6 +11,7 @@
     ":gitSignOff",
     ":assignAndReview(gsuquet)"
   ],
+  "forkProcessing": "enabled",
   "labels": ["renovate"],
   "automergeType": "pr",
   "commitBodyTable": true,
@@ -25,10 +26,23 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "v prefix workaround for action updates",
+      "description": "Prefix all markdown files updates with 'docs'",
+      "matchFileNames": ["**/*.md"],
+      "semanticCommitType": "docs",
+      "semanticCommitScope": null,
+      "automerge": true
+    },
+    {
+      "description": "v prefix workaround for GitHub action updates",
       "matchDepTypes": ["action"],
       "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "Pin Docker images with their SHA256 digest",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchDatasources": ["docker"],
+      "pinDigests": true
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
# Description

- Semantic commit `doc` prefix for all updates related to markdown files  
- Pin the docker images versions using their full sha  
- Process forked repository  

## Type of change

:sparkles: New feature (non-breaking change which adds functionality)  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
